### PR TITLE
mimemagicのバージョンアップ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
## 概要(Overview)
Railsが依存しているmimemagicのライセンスがMITからGPL2.0になってしまい、bundle installができなくなってしまった。
そのため、mimemagicを0.3.9以上に上げて対応をする必要がある。

## 技術的変更点・見所(Technical change)
- mimemagicを0.3.9以上にバージョンアップ

## マイグレーション(Migration)
なし

## 関連URL(Related URL)
https://github.com/rails/rails/issues/41750